### PR TITLE
Add per-IP rate limit to mail.php

### DIFF
--- a/public/mail.php
+++ b/public/mail.php
@@ -1,5 +1,73 @@
 <?php
 
+use Symfony\Component\Dotenv\Dotenv;
+use Mailgun\Mailgun;
+
+// Per-IP submission limits: at most MAIL_RATE_MAX_REQUESTS accepted POSTs per
+// MAIL_RATE_WINDOW_SECONDS. Generous enough that a person submitting a few
+// groups is never blocked, tight enough to stop a bot flooding the inbox.
+const MAIL_RATE_MAX_REQUESTS   = 5;
+const MAIL_RATE_WINDOW_SECONDS = 600;
+
+/**
+ * The address used to bucket the rate limit.
+ *
+ * REMOTE_ADDR is the only value a caller can't forge at the TCP level. If this
+ * app is ever deployed behind a trusted proxy/load balancer, configure the
+ * proxy to pass the real client IP through to REMOTE_ADDR, or read the proxy's
+ * *verified* forwarded header here — never trust a raw X-Forwarded-For, since a
+ * caller can set it to a random value to dodge the limit.
+ */
+function client_ip(): string
+{
+    return $_SERVER['REMOTE_ADDR'] ?? 'unknown';
+}
+
+/**
+ * Sliding-window per-IP rate limit, backed by a lock-guarded temp file.
+ *
+ * Fails open: if the store can't be read or written, the request is allowed
+ * rather than blocking legitimate submissions.
+ */
+function rate_limit_exceeded(string $ip, int $maxRequests, int $windowSeconds): bool
+{
+    $dir = sys_get_temp_dir().'/arm-mail-ratelimit';
+    if (!is_dir($dir) && !@mkdir($dir, 0700, true) && !is_dir($dir)) {
+        return false;
+    }
+
+    $handle = @fopen($dir.'/'.hash('sha256', $ip), 'c+');
+    if ($handle === false) {
+        return false;
+    }
+
+    try {
+        if (!flock($handle, LOCK_EX)) {
+            return false;
+        }
+
+        $now = time();
+        $raw = stream_get_contents($handle);
+        $hits = $raw === '' ? [] : array_map('intval', explode(',', $raw));
+        // Keep only hits still inside the window.
+        $hits = array_values(array_filter($hits, static fn ($t) => $t > $now - $windowSeconds));
+
+        if (count($hits) >= $maxRequests) {
+            return true;
+        }
+
+        $hits[] = $now;
+        rewind($handle);
+        ftruncate($handle, 0);
+        fwrite($handle, implode(',', $hits));
+
+        return false;
+    } finally {
+        flock($handle, LOCK_UN);
+        fclose($handle);
+    }
+}
+
 // Only the group-submission form POSTs here. Reject everything else before
 // loading the framework so a bare GET can't drive this endpoint at all.
 if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST') {
@@ -9,10 +77,14 @@ if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST') {
     exit;
 }
 
-require '../vendor/autoload.php';
+if (rate_limit_exceeded(client_ip(), MAIL_RATE_MAX_REQUESTS, MAIL_RATE_WINDOW_SECONDS)) {
+    http_response_code(429);
+    header('Retry-After: '.MAIL_RATE_WINDOW_SECONDS);
+    echo json_encode('Too Many Requests');
+    exit;
+}
 
-use Symfony\Component\Dotenv\Dotenv;
-use Mailgun\Mailgun;
+require '../vendor/autoload.php';
 
 try {
     // Load environmental variables (only needed locally)


### PR DESCRIPTION
## Summary

Follow-up to the relay fix (#17). Even with the recipient/sender/subject fixed server-side, `mail.php` is still an unauthenticated endpoint that mails `map@veganhacktivists.org` on every valid POST — so a bot could **flood that inbox** with junk submissions. This adds a per-IP rate limit.

## Changes

- **Sliding-window per-IP limit**: at most **5 accepted POSTs per 10 minutes** per client IP. Over the limit returns **`429 Too Many Requests`** with a `Retry-After` header.
- Enforced **before the framework loads**, right after the POST-method gate, so floods are rejected cheaply and GET requests can't consume the budget.
- State is a **lock-guarded temp file** keyed by a SHA-256 of the client IP (`flock` guards against concurrent-request races). No new dependency, no schema, no external service.
- **Fails open**: if the temp store can't be read/written, the request is allowed rather than blocking legitimate submissions.
- Limits are named constants (`MAIL_RATE_MAX_REQUESTS`, `MAIL_RATE_WINDOW_SECONDS`) — easy to tune.

## Validation

Ran the endpoint under a local PHP server:

- 6 valid POSTs from one IP → first **5 pass** the limiter (reach the send), 6th → **`429`** with `Retry-After: 600`.
- `GET` still returns `405` and does **not** consume rate budget.
- `php -l` passes.

## Notes

- **Client IP source:** uses `REMOTE_ADDR` (the only value a caller can't forge at the TCP level). If the app is deployed behind a proxy/load balancer, either pass the real client IP through to `REMOTE_ADDR` at the proxy or read the proxy's *verified* forwarded header — a raw `X-Forwarded-For` must not be trusted, since it can be spoofed to dodge the limit. A comment in the code flags this.
- **Base branch:** this PR targets the #17 branch so its diff shows only the rate-limit change. GitHub will auto-retarget it to `master` when #17 merges; merge #17 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MP7ZheAF7mxKiTNujdqSTD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MP7ZheAF7mxKiTNujdqSTD)_